### PR TITLE
Minimal direct link to report bugs in test files

### DIFF
--- a/templates/index.content.tmpl
+++ b/templates/index.content.tmpl
@@ -40,7 +40,12 @@
   cover all of [% suites.$suite.spec %]. Your help is welcome in this effort.
   [% END %]
   The appropriate mailing list for submitting tests and bug reports is
-  <a href="http://lists.w3.org/Archives/Public/public-css-testsuite/">public-css-testsuite@w3.org</a>.
+  <a href="http://lists.w3.org/Archives/Public/public-css-testsuite/">public-css-testsuite@w3.org</a>.</p>
+  <p>
+  To report bugs or feedback about a specific test file, 
+  search for the filename (without extension) in 
+  <a href="https://github.com/w3c/web-platform-tests/issues">Web Platform Tests Issues</a>, 
+  and file a new issue if necessary with suggested label "wg-css".
   More information on the contribution process and test guidelines is
   available on the <a href="http://wiki.csswg.org/test">wiki
   page</a>.</p>


### PR DESCRIPTION
Provide a direct link to Web Platform Tests issues to file bugs on specific test files since all other wiki / ttwf / wpt docs/sites/homepages are obsolete/opaque on this matter.